### PR TITLE
Add test GitHub action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: GitHub CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+  - cron:  '0 0 * * *'
+    
+env:
+  COMPILE_JOBS: 2
+
+jobs:
+  build:
+    name: Build ${{ matrix.build_type }}-dealii:${{ matrix.dealii_version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        build_type: ["Release", "Debug"]
+        dealii_version: ["master"]
+    
+    container:
+      image: dealii/dealii:${{ matrix.dealii_version }}-focal
+
+    steps:
+      - name: Setup
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+          
+      - uses: actions/checkout@v2
+
+      - name: Compile
+        run: |
+          mkdir build
+          cd build
+          cmake ../ -DCMAKE_CXX_FLAGS="-Werror"  -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+          make -j${{ env.COMPILE_JOBS }}
+          
+      - name: Test
+        run: |
+          cd build
+          ctest -V


### PR DESCRIPTION
This GitHub action runs `ctest` on every pull request and as nightly tests on master. Both master and debug mode are tested.