### PR TITLE
Fix doxygen GitHub action

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -19,6 +19,7 @@ jobs:
       - name: Setup
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+          sudo chown -R $USER:$USER $HOME
           sudo apt-get update
           sudo apt-get install -y doxygen graphviz
 


### PR DESCRIPTION
Fix the failing workflow https://github.com/PartExa/PartExa/runs/4522338030?check_suite_focus=true.
Observed error in the `Deploy` step:
```
Run peaceiris/actions-gh-pages@v3
/usr/bin/docker exec  84b79d2eae4e909fef0b64fc4b57e9bf9a9d3686d3d20921a1a6a36327f4023c sh -c "cat /etc/*release | grep ^ID"
[INFO] Usage https://github.com/peaceiris/actions-gh-pages#readme
Dump inputs
Setup auth token
  [INFO] setup SSH deploy key
  Error: Action failed with "EACCES: permission denied, mkdir '/github/home/.ssh'"
```
Setting the owner of the directory $HOME (`/github/home`) should fix the problem. An alternative would have been to run the container with `options: --user root`.

Following #11