### PR TITLE
Fix failing doxygen GitHub action: root user

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -14,14 +14,13 @@ jobs:
     
     container:
       image: dealii/dealii:master-focal
+      options: --user root
 
     steps:
       - name: Setup
         run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-          sudo chown -R $USER:$USER $HOME
-          sudo apt-get update
-          sudo apt-get install -y doxygen graphviz
+          apt-get update
+          apt-get install -y doxygen graphviz
 
       - uses: actions/checkout@v2
       


### PR DESCRIPTION
According to [this](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#docker-container-filesystem) docker containers should be run using the `root` user in GitHub actions.

The proposed changes should now (hopefully) fix the problem occuring with https://github.com/PartExa/PartExa/runs/4526012475?check_suite_focus=true.

Follows #11, #12