### PR TITLE
Add doxygen info to README.md

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -46,6 +46,7 @@ jobs:
           path: ./build/doc/doxygen/html
 
   deploy:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: build
 
@@ -57,7 +58,6 @@ jobs:
           path: ./build/doc/doxygen/html
 
       - name: Deploy
-        if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           deploy_key: ${{ secrets.ACTIONS_DEPLOY_KEY_DOXYGEN }}

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The major features of PartExa include
 
 Making use of the sophisticated interfaces and data structures provided by deal.II facilitates the coupling of PartExa with other deal.II-based programs.
 
+## Documentation
+
+A source code documentation of PartExa is provided with [Doxygen](https://partexa.github.io/PartExa-Doxygen/).
+
 ## Continuous Integration
 
 [![Indent](https://github.com/PartExa/PartExa/workflows/Indent/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3AIndent)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Making use of the sophisticated interfaces and data structures provided by deal.
 
 [![Indent](https://github.com/PartExa/PartExa/workflows/Indent/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3AIndent)
 [![GitHub CI](https://github.com/PartExa/PartExa/workflows/GitHub%20CI/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3A%22GitHub+CI%22)
+[![Doxygen](https://github.com/PartExa/PartExa/workflows/Doxygen/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3ADoxygen)
 
 ## Releases
 


### PR DESCRIPTION
This PR modifies README.md:
* add a section containing a link to the hosted doxygen page, see here: https://partexa.github.io/PartExa-Doxygen/
* add the doxygen status badge to the README.md

Besides, the condition is moved from the `deploy` step to the overall `deploy` job in the workflow file.