### PR TITLE
Setup basic sphinx configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.12.0)
 
 ADD_SUBDIRECTORY(cmake)
 
+LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules/)
+
 PRINT_PARTEXA_HEADER()
 
 # deal.II
@@ -89,7 +91,7 @@ ADD_CUSTOM_TARGET(release
   )
 
 # enable documentation
-ADD_SUBDIRECTORY(doc/doxygen)
+ADD_SUBDIRECTORY(doc)
 
 # enable testing framework
 ENABLE_TESTING()

--- a/cmake/modules/FindSphinx.cmake
+++ b/cmake/modules/FindSphinx.cmake
@@ -19,21 +19,14 @@
 ##
 ## ---------------------------------------------------------------------
 
-FIND_PACKAGE(Doxygen QUIET)
+FIND_PROGRAM(SPHINX_EXECUTABLE
+  NAMES sphinx-build
+  DOC "Path to sphinx-build executable"
+  )
 
-IF (${DOXYGEN_FOUND})
+INCLUDE(FindPackageHandleStandardArgs)
 
-  MESSAGE("-- Configuring Doxygen documentation")
-
-  CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    )
-    
-  ADD_CUSTOM_TARGET(doxygen
-    COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile > doxygen.out
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Generating Doxygen documentation"
-    )
-
-ENDIF ()
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Sphinx
+  "Failed to find sphinx-build executable"
+  SPHINX_EXECUTABLE
+  )

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -19,21 +19,5 @@
 ##
 ## ---------------------------------------------------------------------
 
-FIND_PACKAGE(Doxygen QUIET)
-
-IF (${DOXYGEN_FOUND})
-
-  MESSAGE("-- Configuring Doxygen documentation")
-
-  CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    )
-    
-  ADD_CUSTOM_TARGET(doxygen
-    COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile > doxygen.out
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Generating Doxygen documentation"
-    )
-
-ENDIF ()
+ADD_SUBDIRECTORY(doxygen)
+ADD_SUBDIRECTORY(sphinx)

--- a/doc/sphinx/CMakeLists.txt
+++ b/doc/sphinx/CMakeLists.txt
@@ -19,21 +19,20 @@
 ##
 ## ---------------------------------------------------------------------
 
-FIND_PACKAGE(Doxygen QUIET)
+FIND_PACKAGE(Sphinx QUIET)
 
-IF (${DOXYGEN_FOUND})
+IF (${SPHINX_FOUND})
 
-  MESSAGE("-- Configuring Doxygen documentation")
+  MESSAGE("-- Configuring Sphinx documentation")
 
-  CONFIGURE_FILE(
-    ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in
-    ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
-    )
-    
-  ADD_CUSTOM_TARGET(doxygen
-    COMMAND ${DOXYGEN_EXECUTABLE} Doxyfile > doxygen.out
+  SET(SPHINX_SOURCE ${CMAKE_CURRENT_SOURCE_DIR})
+  SET(SPHINX_BUILD ${CMAKE_CURRENT_BINARY_DIR}/html)
+  SET(PARTEXA_LOGO ${CMAKE_SOURCE_DIR}/doc/logo/logo_white_rounded_small.png)
+
+  ADD_CUSTOM_TARGET(sphinx
+    COMMAND ${SPHINX_EXECUTABLE} -b html -w sphinx.err -Dhtml_logo=${PARTEXA_LOGO} ${SPHINX_SOURCE} ${SPHINX_BUILD} > sphinx.out
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-    COMMENT "Generating Doxygen documentation"
+    COMMENT "Generating Sphinx documentation"
     )
 
 ENDIF ()

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -1,0 +1,49 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+# import os
+# import sys
+# sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'PartExa - A Particle Library for the Exa-Scale'
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = []
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'sphinx_rtd_theme'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']

--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -1,0 +1,33 @@
+.. ---------------------------------------------------------------------
+..
+.. PartExa - A Particle Library for the Exa-Scale
+..
+.. Copyright (C) 2021 by the PartExa authors
+..
+.. This program is free software: you can redistribute it and/or modify
+.. it under the terms of the GNU General Public License as published by
+.. the Free Software Foundation, either version 3 of the License, or
+.. (at your option) any later version.
+..
+.. This program is distributed in the hope that it will be useful,
+.. but WITHOUT ANY WARRANTY; without even the implied warranty of
+.. MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+.. GNU General Public License for more details.
+..
+.. You should have received a copy of the GNU General Public License
+.. along with this program. If not, see <https://www.gnu.org/licenses/>.
+..
+.. ---------------------------------------------------------------------
+
+PartExa - A Particle Library for the Exa-Scale
+==============================================
+
+PartExa is an open-source particle library written in C++ using state-of-the-art programming
+techniques. PartExa strongly depends on the finite element library 
+`deal.II <https://www.dealii.org/>`_ along with `p4est <https://www.p4est.org/>`_ for parallel 
+distributed adaptive quadtrees and octrees. deal.II provides basic particle functionality with a
+strong focus on efficient data structures and aspects of parallelization.
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,22 @@
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2021 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
 ADD_SUBDIRECTORY(base)

--- a/tests/base/CMakeLists.txt
+++ b/tests/base/CMakeLists.txt
@@ -1,2 +1,23 @@
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2021 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
 SET (TEST_LIBRARIES partexa)
 DEAL_II_PICKUP_TESTS()


### PR DESCRIPTION
This sets up a basic sphinx documentation. 

In order to build the sphinx documentation it is required to install sphinx
```
python -m venv .venv
source .venv/bin/activate
python -m pip install sphinx
pip install sphinx_rtd_theme
```
These steps have to be done before running `cmake`.
The basic configuration is taken from [here](https://devblogs.microsoft.com/cppblog/clear-functional-c-documentation-with-sphinx-breathe-doxygen-cmake/) and [here](https://www.sphinx-doc.org/en/master/tutorial/getting-started.html).