### PR TITLE
Prevent failing workflow in forks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -3,6 +3,8 @@ name: Coverage
 on:
   push:
     branches: [ master ]
+  pull_request:
+    branches: [ master ]
   schedule:
   - cron:  '0 0 * * 0'
   workflow_dispatch:
@@ -45,7 +47,7 @@ jobs:
           path: ./coverage_report
 
   deploy:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository_owner == 'PartExa' && ( github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ) }}
     runs-on: ubuntu-latest
     needs: build
 

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -46,7 +46,7 @@ jobs:
           path: ./build/doc/doxygen/html
 
   deploy:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository_owner == 'PartExa' && ( github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ) }}
     runs-on: ubuntu-latest
     needs: build
 

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -55,7 +55,7 @@ jobs:
           path: ./build/doc/sphinx/html
 
   deploy:
-    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ github.repository_owner == 'PartExa' && ( github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' ) }}
     runs-on: ubuntu-latest
     needs: build
 


### PR DESCRIPTION
Execute the `deploy` job for the `Doxygen`, `Sphinx`, and `Coverage` workflow only if run in the PartExa/PartExa repository and not in forks of it.

All these workflows named above currently run on `push`, `pull_request`, and once a week. Besides they can be triggered manually. These rules can to be revised in the future anytime. Currently, with short runs this is not an issue.