### PR TITLE
Generate project badges

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup
         run: |
           apt-get update
-          apt-get install -y lcov
+          apt-get install -y lcov bc
           
       - uses: actions/checkout@v2
 
@@ -40,6 +40,13 @@ jobs:
           lcov --remove coverage.info '*/tests/*' '*/CMakeCXXCompilerId.cpp' -o coverage_filtered.info >> coverage.out 2>> coverage.err  2>> coverage.err
           genhtml coverage_filtered.info --legend --demangle-cpp --output-directory ./coverage_report --title "PartExa coverage report" >> coverage.out 2>> coverage.err
           grep "Overall coverage rate:" -A 2 coverage.out
+
+      - name: Badge
+        run: |
+          mkdir ./coverage_report/badge
+          CVGE="$(grep "Overall coverage rate:" -A 2 coverage.out | grep "lines" | grep -oE "[[:digit:]]{1,3}.[[:digit:]]")"
+          if (( $(echo "$CVGE < 75.0" | bc -l) )); then COLOR=E03E28; elif (( $(echo "$CVGE < 90.0" | bc -l) )); then COLOR=E8C62E; else COLOR=34D058; fi
+          wget "https://img.shields.io/static/v1?label=Coverage&labelColor=323940&message=$CVGE%25&color=$COLOR" -O ./coverage_report/badge/badge.svg
 
       - name: Upload artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -39,6 +39,11 @@ jobs:
           if [ ! -f doxygen.err ]; then echo "No Doxygen error file found!"; exit 1; fi
           if [ -s doxygen.err ]; then echo "Doxygen failed with the following error(s):"; cat doxygen.err; exit 1; else echo "Doxygen passed."; fi
 
+      - name: Badge
+        run: |
+          mkdir ./build/doc/doxygen/html/badge
+          wget "https://img.shields.io/static/v1?label=Doc&labelColor=323940&message=Doxygen&color=blue" -O ./build/doc/doxygen/html/badge/badge.svg
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -48,6 +48,11 @@ jobs:
           if [ ! -f sphinx.err ]; then echo "No Sphinx error file found!"; exit 1; fi
           if [ -s sphinx.err ]; then echo "Sphinx failed with the following error(s):"; cat sphinx.err; exit 1; else echo "Sphinx passed."; fi
 
+      - name: Badge
+        run: |
+          mkdir ./build/doc/sphinx/html/badge
+          wget "https://img.shields.io/static/v1?label=Doc&labelColor=323940&message=Sphinx&color=blue" -O ./build/doc/sphinx/html/badge/badge.svg
+
       - name: Upload artifact
         uses: actions/upload-artifact@v2
         with:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # PartExa - A Particle Library for the Exa-Scale
 
+[![Code Checks](https://github.com/PartExa/PartExa/workflows/Code%20Checks/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3A%22Code+Checks%22)
+[![GitHub CI](https://github.com/PartExa/PartExa/workflows/GitHub%20CI/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3A%22GitHub+CI%22)
+[![Coverage](https://github.com/PartExa/PartExa-Coverage/blob/master/badge/badge.svg)](https://partexa.github.io/PartExa-Coverage/)
+[![Sphinx](https://github.com/PartExa/PartExa-Sphinx/blob/master/badge/badge.svg)](https://partexa.github.io/PartExa-Sphinx/)
+[![Doxygen](https://github.com/PartExa/PartExa-Doxygen/blob/master/badge/badge.svg)](https://partexa.github.io/PartExa-Doxygen/)
+
 <img align="right" width="120" height="120" src="doc/logo/logo_gray_rounded.png">
 
 PartExa is an open-source particle library written in C++ using state-of-the-art programming techniques. PartExa strongly depends on the finite element library [deal.II](https://www.dealii.org/) along with [p4est](https://www.p4est.org/) for parallel distributed adaptive quadtrees and octrees. deal.II provides basic particle functionality with a strong focus on efficient data structures and aspects of parallelization.
@@ -21,14 +27,6 @@ The documentation of PartExa is twofold and based on
 * and a source code documentation provided with [Doxygen](https://partexa.github.io/PartExa-Doxygen/).
 
 Besides, the test coverage of PartExa is given in this [coverage report](https://partexa.github.io/PartExa-Coverage/).
-
-## Continuous Integration
-
-[![Indent](https://github.com/PartExa/PartExa/workflows/Indent/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3AIndent)
-[![GitHub CI](https://github.com/PartExa/PartExa/workflows/GitHub%20CI/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3A%22GitHub+CI%22)
-[![Sphinx](https://github.com/PartExa/PartExa/workflows/Sphinx/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3ASphinx)
-[![Doxygen](https://github.com/PartExa/PartExa/workflows/Doxygen/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3ADoxygen)
-[![Coverage](https://github.com/PartExa/PartExa/workflows/Coverage/badge.svg)](https://github.com/PartExa/PartExa/actions?query=workflow%3ACoverage)
 
 ## Releases
 


### PR DESCRIPTION
Add `badge` steps to several workflows to generate a coverage badge and documentation badge that can be included in the README.md.