### PR TITLE
introduce configuration scripts

### DIFF
--- a/utilities/configure_scripts/configure_dealii.sh
+++ b/utilities/configure_scripts/configure_dealii.sh
@@ -23,7 +23,7 @@
 # You may want to deactivate this line
 rm -rf CMakeFiles/ CMakeCache.txt
 
-# It is recommended to copy this file to your PartExa build directory via
+# It is recommended to copy this file to your deal.II build directory via
 # ```bash
 # cd <dealii_build>
 # cp <partexa_source>/utilities/configure_scripts/configure_partexa.sh .

--- a/utilities/configure_scripts/configure_dealii.sh
+++ b/utilities/configure_scripts/configure_dealii.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2022 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+# You may want to deactivate this line
+rm -rf CMakeFiles/ CMakeCache.txt
+
+# It is recommended to copy this file to your PartExa build directory via
+# ```bash
+# cd <dealii_build>
+# cp <partexa_source>/utilities/configure_scripts/configure_partexa.sh .
+# ```
+
+# Having copied the file, you need to adjust the paths specified below
+P4EST=/path/to/p4est
+DEAL=/path/to/dealii
+
+cmake \
+    -D CMAKE_BUILD_TYPE="DebugRelease" \
+    -D CMAKE_CXX_FLAGS="-std=c++17 -march=native -Wno-array-bounds -Wno-literal-suffix -pthread" \
+    -D DEAL_II_CXX_FLAGS_RELEASE="-O3" \
+    -D DEAL_II_CXX_FLAGS_DEBUG="-Og" \
+    -D CMAKE_C_FLAGS="-march=native -Wno-array-bounds" \
+    -D DEAL_II_WITH_MPI:BOOL="ON" \
+    -D DEAL_II_LINKER_FLAGS="-lpthread" \
+    -D DEAL_II_WITH_64BIT_INDICES="ON" \
+    -D DEAL_II_WITH_P4EST="ON" \
+    -D P4EST_DIR="$P4EST" \
+    -D DEAL_II_COMPONENT_DOCUMENTATION="OFF" \
+    -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
+    $DEAL

--- a/utilities/configure_scripts/configure_dealii.sh
+++ b/utilities/configure_scripts/configure_dealii.sh
@@ -23,27 +23,16 @@
 # You may want to deactivate this line
 rm -rf CMakeFiles/ CMakeCache.txt
 
-# It is recommended to copy this file to your deal.II build directory via
-# ```bash
-# cd <dealii_build>
-# cp <partexa_source>/utilities/configure_scripts/configure_partexa.sh .
-# ```
+# It is recommended to copy this file to your deal.II build directory.
 
 # Having copied the file, you need to adjust the paths specified below
 P4EST=/path/to/p4est
 DEAL=/path/to/dealii
+DEAL_INSTALL=/path/to/dealii_install
 
 cmake \
-    -D CMAKE_BUILD_TYPE="DebugRelease" \
-    -D CMAKE_CXX_FLAGS="-std=c++17 -march=native -Wno-array-bounds -Wno-literal-suffix -pthread" \
-    -D DEAL_II_CXX_FLAGS_RELEASE="-O3" \
-    -D DEAL_II_CXX_FLAGS_DEBUG="-Og" \
-    -D CMAKE_C_FLAGS="-march=native -Wno-array-bounds" \
-    -D DEAL_II_WITH_MPI:BOOL="ON" \
-    -D DEAL_II_LINKER_FLAGS="-lpthread" \
-    -D DEAL_II_WITH_64BIT_INDICES="ON" \
+    -D CMAKE_INSTALL_PREFIX="$DEAL_INSTALL" \
+    -D DEAL_II_WITH_MPI="ON" \
     -D DEAL_II_WITH_P4EST="ON" \
     -D P4EST_DIR="$P4EST" \
-    -D DEAL_II_COMPONENT_DOCUMENTATION="OFF" \
-    -D DEAL_II_COMPONENT_EXAMPLES="OFF" \
     $DEAL

--- a/utilities/configure_scripts/configure_partexa.sh
+++ b/utilities/configure_scripts/configure_partexa.sh
@@ -23,14 +23,10 @@
 # You may want to deactivate this line
 rm -rf CMakeFiles/ CMakeCache.txt
 
-# It is recommended to copy this file to your PartExa build directory via
-# ```bash
-# cd <partexa_build>
-# cp <partexa_source>/utilities/configure_scripts/configure_partexa.sh .
-# ```
+# It is recommended to copy this file to your PartExa build directory.
 
 # Having copied the file, you need to adjust the paths specified below
-PARTEXA_SOURCE=../
+PARTEXA_SOURCE=/path/to/partexa
 DEAL_BUILD_OR_INSTALL=/path/to/dealii
 
 # You may want to switch between Debug/Release mode

--- a/utilities/configure_scripts/configure_partexa.sh
+++ b/utilities/configure_scripts/configure_partexa.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2022 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+# You may want to deactivate this line
+rm -rf CMakeFiles/ CMakeCache.txt
+
+# It is recommended to copy this file to your PartExa build directory via
+# ```bash
+# cd <partexa_build>
+# cp <partexa_source>/utilities/configure_scripts/configure_partexa.sh .
+# ```
+
+# Having copied the file, you need to adjust the paths specified below
+PARTEXA_SOURCE=../
+DEAL_BUILD_OR_INSTALL=/path/to/dealii
+
+# You may want to switch between Debug/Release mode
+cmake \
+    -D CMAKE_BUILD_TYPE="Release" \
+    -D BUILD_SHARED_LIBS=OFF \
+    -D DEAL_II_DIR="$DEAL_BUILD_OR_INSTALL" \
+    $PARTEXA_SOURCE


### PR DESCRIPTION
I think it makes sense to introduce configuration scripts already right now. My experience is that we will otherwise have to adjust the documentation of the configuration process very often whenever adding new options. More importantly, typing the cmake command into the command line is also error prone if it becomes longer and longer, and it makes sense to make the settings permanent by storing the paths in a configuration file.

In another commit, I would add a similar script for the dealii configuration.