### PR TITLE
Add clang-format check

### DIFF
--- a/utilities/clang-format/run-check-on-current-branch.sh
+++ b/utilities/clang-format/run-check-on-current-branch.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2022 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+# get source directory
+SOURCE_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+# check for correct source directory
+if [[ ! -f ${SOURCE_DIR}/CMakeLists.txt ]]; then
+  echo "This script must be run from within the git repository!"
+  exit 1
+fi
+
+# change to source directory
+cd $SOURCE_DIR
+
+# check for uncommitted changes
+if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+  echo "The git repository contains uncommitted changes!"
+  exit 1
+fi
+
+# get all changed files on current branch with respect to master branch
+relevant_files=$(git diff --name-only --diff-filter=ACMR origin/master...HEAD 2>/dev/null)
+
+# check formatting of relevant files
+for file in $relevant_files; do
+  if [[ $file == *.cpp || $file == *.cc || $file == *.H || $file == *.h || $file == *.hpp ]]; then
+    clang-format -style=file -i $file
+  fi
+done

--- a/utilities/clang-format/run-check-on-current-head.sh
+++ b/utilities/clang-format/run-check-on-current-head.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2022 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+# get source directory
+SOURCE_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+# check for correct source directory
+if [[ ! -f ${SOURCE_DIR}/CMakeLists.txt ]]; then
+  echo "This script must be run from within the git repository!"
+  exit 1
+fi
+
+# change to source directory
+cd $SOURCE_DIR
+
+# check for uncommitted changes
+if [[ -n $(git status --porcelain 2>/dev/null) ]]; then
+  echo "The git repository contains uncommitted changes!"
+  exit 1
+fi
+
+# get all files as of current commit
+relevant_files=$(git ls-tree -r --name-only HEAD 2>/dev/null)
+
+# check formatting of relevant files
+for file in $relevant_files; do
+  if [[ $file == *.cpp || $file == *.cc || $file == *.H || $file == *.h || $file == *.hpp ]]; then
+    clang-format -style=file -i $file
+  fi
+done

--- a/utilities/clang-format/run-check-on-indexed-files.sh
+++ b/utilities/clang-format/run-check-on-indexed-files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+## ---------------------------------------------------------------------
+##
+## PartExa - A Particle Library for the Exa-Scale
+##
+## Copyright (C) 2022 by the PartExa authors
+##
+## This program is free software: you can redistribute it and/or modify
+## it under the terms of the GNU General Public License as published by
+## the Free Software Foundation, either version 3 of the License, or
+## (at your option) any later version.
+##
+## This program is distributed in the hope that it will be useful,
+## but WITHOUT ANY WARRANTY; without even the implied warranty of
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+## GNU General Public License for more details.
+##
+## You should have received a copy of the GNU General Public License
+## along with this program. If not, see <https://www.gnu.org/licenses/>.
+##
+## ---------------------------------------------------------------------
+
+# get source directory
+SOURCE_DIR="$(git rev-parse --show-toplevel 2>/dev/null)"
+
+# check for correct source directory
+if [[ ! -f ${SOURCE_DIR}/CMakeLists.txt ]]; then
+  echo "This script must be run from within the git repository!"
+  exit 1
+fi
+
+# change to source directory
+cd $SOURCE_DIR
+
+# get all indexed files
+relevant_files=$(git diff-index --cached --name-only --diff-filter=ACMR HEAD 2>/dev/null)
+
+# check formatting of relevant files
+for file in $relevant_files; do
+  if [[ $file == *.cpp || $file == *.cc || $file == *.H || $file == *.h || $file == *.hpp ]]; then
+    clang-format -style=file -i $file
+  fi
+done


### PR DESCRIPTION
The clang-format check comes for three different cases:
- check all files in the repo on HEAD
- check all files changed on a branch where HEAD points with respect to master
- check all indexed files prior to a commit

Note: Currently clang-format needs to be provided by the user. This will change with a future PR and clang-format will be provided automatically such that the user does not need to take care of that manually.