### PR TITLE
Adapt gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,32 +1,15 @@
-# Prerequisites
-*.d
+# temporary files
+*~
+*.swp
+*.swo
 
-# Compiled Object files
-*.slo
-*.lo
-*.o
-*.obj
+# eclipse
+/.cproject
+/.project
+/.settings
 
-# Precompiled Headers
-*.gch
-*.pch
+# visual studio code
+/.vscode
 
-# Compiled Dynamic libraries
-*.so
-*.dylib
-*.dll
-
-# Fortran module files
-*.mod
-*.smod
-
-# Compiled Static libraries
-*.lai
-*.la
-*.a
-*.lib
-
-# Executables
-*.exe
-*.out
-*.app
+# clion
+/.idea


### PR DESCRIPTION
The default `.gitignore` files as created by GitHub during project initialization contains many entries that are not required for PartExa. Especially as we want to encourage out-source builds. Depending on the outcome of https://github.com/PartExa/PartExa/pull/32#issuecomment-1045997011 we probably even prevent in-source builds soon.

This PR adapts the `.gitignore` file such that currently only temporary files (e.g. from vim) or IDE specific files (Eclipse, VS Code, Clion) are ignored.